### PR TITLE
Use `f64` type in layout

### DIFF
--- a/src/layout_abstract_syntax.rs
+++ b/src/layout_abstract_syntax.rs
@@ -108,7 +108,7 @@ impl Attribute {
 	}
 
 	/// Extracts a percentage from this attribute's value.
-	fn percent(self) -> f32 {
+	fn percent(self) -> f64 {
 		match self.dimension() {
 			Dimension::Percent(value) => value,
 			_ => panic!("expected a percentage"),
@@ -151,8 +151,8 @@ pub enum AttributeValue {
 pub struct LayoutAttributes {
 	pub width: Dimension,
 	pub height: Dimension,
-	pub x_align: f32,
-	pub y_align: f32,
+	pub x_align: f64,
+	pub y_align: f64,
 	pub spacing: BoxDimensions,
 	pub padding: BoxDimensions,
 }

--- a/src/layout_abstract_types.rs
+++ b/src/layout_abstract_types.rs
@@ -76,11 +76,11 @@ pub enum TemplateStringSegment {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Dimension {
 	/// Absolute value in pixels.
-	AbsolutePx(f32),
+	AbsolutePx(f64),
 	/// Percent of parent container size along the same axis.
-	Percent(f32),
+	Percent(f64),
 	/// Percent of free space remaining in parent container.
-	PercentRemainder(f32),
+	PercentRemainder(f64),
 	/// Minimum size required to fit the children.
 	Inner,
 	/// Size relative to the width of this component.

--- a/src/layout_attribute_parser.rs
+++ b/src/layout_attribute_parser.rs
@@ -128,7 +128,7 @@ impl AttributeParser {
 			// AbsolutePx: px
 			Some([value, px]) if px.eq_ignore_ascii_case("px") => {
 				let pixels = value
-					.parse::<f32>()
+					.parse::<f64>()
 					.expect(&format!("Invalid value `{}` specified in the attribute type`{}` when parsing XML layout", value, attribute_type)[..]);
 				let dimension = Dimension::AbsolutePx(pixels);
 				TypeValueOrArgument::TypeValue(TypeValue::Dimension(dimension))
@@ -136,7 +136,7 @@ impl AttributeParser {
 			// Percent: ?%
 			Some([value, "%"]) => {
 				let percent = value
-					.parse::<f32>()
+					.parse::<f64>()
 					.expect(&format!("Invalid value `{}` specified in the attribute type `{}` when parsing XML layout", value, attribute_type)[..]);
 				let dimension = Dimension::Percent(percent);
 				TypeValueOrArgument::TypeValue(TypeValue::Dimension(dimension))
@@ -144,7 +144,7 @@ impl AttributeParser {
 			// PercentRemainder: ?@
 			Some([value, "@"]) => {
 				let percent_remainder = value
-					.parse::<f32>()
+					.parse::<f64>()
 					.expect(&format!("Invalid value `{}` specified in the attribute type `{}` when parsing XML layout", value, attribute_type)[..]);
 				let dimension = Dimension::PercentRemainder(percent_remainder);
 				TypeValueOrArgument::TypeValue(TypeValue::Dimension(dimension))


### PR DESCRIPTION
Updates the layout system to use double-precision floating point numbers.

When performing layout, the extra precision is useful to avoid rounding errors. At the same time, we probably wouldn't get much of a performance improvement from using `f32`s in this context.